### PR TITLE
new test and minor fix in imports path

### DIFF
--- a/conans/client/loader_parse.py
+++ b/conans/client/loader_parse.py
@@ -66,7 +66,7 @@ def _parse_file(conan_file_path):
     filename = os.path.splitext(os.path.basename(conan_file_path))[0]
 
     try:
-        current_dir = os.path.dirname(conan_file_path) or "."
+        current_dir = os.path.dirname(conan_file_path)
         sys.path.append(current_dir)
         old_modules = list(sys.modules.keys())
         with chdir(current_dir):

--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -282,12 +282,14 @@ class ConanManager(object):
         if inject_require:
             output = ScopedOutput("%s test package" % str(inject_require), self._user_io.out)
             output.info("Installing dependencies")
-        elif not isinstance(reference, ConanFileReference):
-            output = ScopedOutput("PROJECT", self._user_io.out)
-            Printer(self._user_io.out).print_graph(deps_graph, registry)
         else:
-            output = ScopedOutput(str(reference), self._user_io.out)
-            output.highlight("Installing package")
+            if not isinstance(reference, ConanFileReference):
+                output = ScopedOutput("PROJECT", self._user_io.out)
+                output.highlight("Installing %s" % reference)
+            else:
+                output = ScopedOutput(str(reference), self._user_io.out)
+                output.highlight("Installing package")
+            Printer(self._user_io.out).print_graph(deps_graph, registry)
 
         try:
             if loader._settings.os and detected_os() != loader._settings.os:
@@ -357,6 +359,8 @@ class ConanManager(object):
                 conan_file_path = os.path.join(reference, CONANFILE)
                 if not os.path.exists(conan_file_path):
                     conan_file_path = os.path.join(reference, CONANFILE_TXT)
+            elif not os.path.isabs(conan_file_path):
+                conan_file_path = os.path.abspath(os.path.join(reference, conan_file_path))
             reference = None
         else:
             output = ScopedOutput(str(reference), self._user_io.out)

--- a/conans/test/integration/load_requires_file_test.py
+++ b/conans/test/integration/load_requires_file_test.py
@@ -1,0 +1,36 @@
+import unittest
+
+from conans.test.utils.tools import TestClient
+
+
+class LoadRequiremensTextFileTest(unittest.TestCase):
+
+    def load_reqs_from_text_file_test(self):
+        client = TestClient()
+        conanfile = """from conans import ConanFile, load
+def reqs():
+    try:
+        content = load("reqs.txt")
+        lines = [line for line in content.splitlines() if line]
+        return tuple(lines)
+    except:
+        return None
+
+class Test(ConanFile):
+    exports = "reqs.txt"
+    requires = reqs()
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("create Hello0/0.1@user/channel")
+
+        for i in (0, 1, 2):
+            reqs = "Hello%s/0.1@user/channel" % i
+            client.save({"conanfile.py": conanfile,
+                         "reqs.txt": reqs})
+            client.run("create Hello%s/0.1@user/channel" % (i + 1))
+
+        client.run("install Hello3/0.1@user/channel")
+        self.assertIn("Hello0/0.1@user/channel from local", client.out)
+        self.assertIn("Hello1/0.1@user/channel from local", client.out)
+        self.assertIn("Hello2/0.1@user/channel from local", client.out)
+        self.assertIn("Hello3/0.1@user/channel from local", client.out)

--- a/conans/test/integration/load_requires_file_test.py
+++ b/conans/test/integration/load_requires_file_test.py
@@ -3,7 +3,7 @@ import unittest
 from conans.test.utils.tools import TestClient
 
 
-class LoadRequiremensTextFileTest(unittest.TestCase):
+class LoadRequirementsTextFileTest(unittest.TestCase):
 
     def load_reqs_from_text_file_test(self):
         client = TestClient()


### PR DESCRIPTION
- Added new test
~~- Removed the "." in the loader, it was necessary only because of some test failing in imports, but I fixed it there. ``conanfile_path`` should be always absolute. Did you added it because of the imports test failing?.~~
UPDATE: Just read your closed PR https://github.com/conan-io/conan/pull/1527. Now it is clear, thanks. This PR should fix it.
- I am also changing the output while installing things, we did some changes in 0.25 that weren't really good, and I am fixing it. Added here because I use that output in the test.